### PR TITLE
nobug: enable printing local messages in color

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   CI:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Compile
         run: go build ./...

--- a/color.go
+++ b/color.go
@@ -1,0 +1,49 @@
+package netlog
+
+import (
+	"fmt"
+)
+
+const (
+	reset  = "\033[0m"
+	red    = "\033[31m"
+	green  = "\033[32m"
+	yellow = "\033[33m"
+	blue   = "\033[34m"
+	purple = "\033[35m"
+	cyan   = "\033[36m"
+	gray   = "\033[37m"
+	white  = "\033[97m"
+)
+
+func apply(color, format string, args ...any) string {
+	return color + fmt.Sprintf(format, args...) + reset
+}
+
+func Red(format string, args ...any) {
+	fmt.Println(apply(red, format, args...))
+}
+
+func Green(format string, args ...any) {
+	fmt.Println(apply(green, format, args...))
+}
+
+func Yellow(format string, args ...any) {
+	fmt.Println(apply(yellow, format, args...))
+}
+
+func Blue(format string, args ...any) {
+	fmt.Println(apply(blue, format, args...))
+}
+
+func Purple(format string, args ...any) {
+	fmt.Println(apply(purple, format, args...))
+}
+
+func Cyan(format string, args ...any) {
+	fmt.Println(apply(cyan, format, args...))
+}
+
+func White(format string, args ...any) {
+	fmt.Println(apply(white, format, args...))
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gophers.dev/pkgs/netlog
 
-go 1.17
+go 1.18
 
 require (
 	github.com/google/subcommands v1.2.0


### PR DESCRIPTION
Apart from logging over the net, enable printing local
log messages in color for help in debugging.
